### PR TITLE
Build: Updated GCP Credentials Filename

### DIFF
--- a/.github/workflows/auth-server-ci.yml
+++ b/.github/workflows/auth-server-ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Authenticate with Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+          credentials_json: ${{ secrets.GCP_CREDENTIALS  }}
 
       # Setup Docker auth for Artifact Registry
       - name: Configure Docker for Artifact Registry


### PR DESCRIPTION
The GCP file name was not correct in the auth-server-ci file which lead to error while authenticating with the Geofield cloud.

The file name is now updated with the correct one.